### PR TITLE
Fixed #8 UnicodeEncodeError after latest Sublime update

### DIFF
--- a/SimpleSync.py
+++ b/SimpleSync.py
@@ -82,7 +82,7 @@ class LocalCopier(threading.Thread):
     print("SimpleSync: ", self.local_file, " -> ", self.remote_file)
 
     for line in runProcess(['cp', self.local_file, self.remote_file]):
-      print(line, end='')
+      print(line.encode('ascii', 'ignore'), end='')
 
 #
 # Subclass sublime_plugin.EventListener

--- a/SimpleSync.py
+++ b/SimpleSync.py
@@ -67,7 +67,7 @@ class ScpCopier(threading.Thread):
     print("SimpleSync: ", self.local_file, " -> ", remote)
 
     for line in runProcess(["scp", "-r", "-P", str(self.port) , self.local_file, remote]):
-      print(line, end='')
+      print(line.encode('ascii', 'ignore'), end='')
 
 #
 # LocalCopier does local copying using threading to avoid UI blocking


### PR DESCRIPTION
When working in an OS with a language different than english, python complains with that error if the returned message from the command contains special characters.

I used the solution provided here: http://stackoverflow.com/questions/3224268/python-unicode-encode-error
