### PR TITLE
Add a sync on opening the file...

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simple Sublime Text 2/3 plugin for SSH and local syncing.
 
 ## Installation
 
-### Using ST2/3 Package Control ([https://packagecontrol.io/installation])
+### Using ST2/3 [Package Control](https://packagecontrol.io/installation)
 
 Search for SimpleSync in ST2/3 Package Control and install it.
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Search for SimpleSync in ST2/3 Package Control and install it.
 Clone this project into your ST2 Packages folder, for example:
 
 ``` bash
-cd "~/Library/Application Support/Sublime Text 2/Packages"
+cd ~/"Library/Application Support/Sublime Text 2/Packages"
 git clone https://github.com/hydralien/SimpleSync.git
 ```
 
 * Sublime Text 3
 
 ``` bash
-cd "~/Library/Application Support/Sublime Text 3/Packages"
+cd ~/"Library/Application Support/Sublime Text 3/Packages"
 git clone https://github.com/hydralien/SimpleSync.git
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Files are saved to remote server automatically when you save them locally. In ca
 
 Also when you open a file, it checks its remote counterpart for if it's different (if, say, repository was updated) and asks you to refresh local copy if that's the case. You can switchi this change off by specifying "sync_on_open" : false in user config, like e.g.
 
+``` javascript
 {
   "sync_on_open" : false,
   "sync": [{

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*Previously maintained by [Tan Nhu](https://github.com/tnhu) at [https://github.com/tnhu/SimpleSync](https://github.com/tnhu/SimpleSync)*
+
 # SimpleSync
 
 Simple Sublime Text 2/3 plugin for SSH and local syncing.
@@ -76,6 +78,7 @@ Also when you open a file, it checks its remote counterpart for if it's differen
 
 * [tnhu](https://github.com/tnhu)
 * [gfreezy](https://github.com/gfreezy)
+* [hydralien](https://github.com/hydralien/SimpleSync)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ Sample settings:
 
 Files are saved to remote server automatically when you save them locally. In case of "local" syncing, they are copied to "remote" folder which is on the same machine.
 
+Also when you open a file, it checks its remote counterpart for if it's different (if, say, repository was updated) and asks you to refresh local copy if that's the case. You can switchi this change off by specifying "sync_on_open" : false in user config, like e.g.
+
+{
+  "sync_on_open" : false,
+  "sync": [{
+    "type"     : "ssh",
+    "host"     : "tnhu-ld",
+    "port"     : "22",
+    "username" : "tnhu",
+    "local"    : "/Users/tnhu/workspace/trunk",
+    "remote"   : "/home/tnhu/workspace/trunk"
+  }]
+}
+```
+
 ## Contributors
 
 * [tnhu](https://github.com/tnhu)

--- a/README.md
+++ b/README.md
@@ -11,33 +11,34 @@ Simple Sublime Text 2/3 plugin for SSH and local syncing.
 
 ## Installation
 
+### Using ST2/3 Package Control ([https://packagecontrol.io/installation])
+
+Search for SimpleSync in ST2/3 Package Control and install it.
+
+
 ### Manually
 
 * Sublime Text 2
 Clone this project into your ST2 Packages folder, for example:
 
 ``` bash
-cd "/Users/tnhu/Library/Application Support/Sublime Text 2/Packages"
-git clone https://github.com/tnhu/SimpleSync.git
+cd "~/Library/Application Support/Sublime Text 2/Packages"
+git clone https://github.com/hydralien/SimpleSync.git
 ```
 
 * Sublime Text 3
 
 ``` bash
-cd "/Users/tnhu/Library/Application Support/Sublime Text 3/Packages"
-git clone https://github.com/tnhu/SimpleSync.git
+cd "~/Library/Application Support/Sublime Text 3/Packages"
+git clone https://github.com/hydralien/SimpleSync.git
 ```
-
-### Using ST2/3 Package Control
-
-Search for SimpleSync in ST2/3 Package Control and install it.
 
 ## Settings
 
 When you finish installing SimpleSync, its settings can be found in Preferences > Package Settings > SimpleSync > Settings - Default.
 And you should put your custom settings in Preferences > Package Settings > SimpleSync > Settings - User.
 
-Sample settings:
+Sample settings (remember to replace "username" with yours and adjust paths if needed):
 
 ``` javascript
 {
@@ -46,12 +47,12 @@ Sample settings:
     "host"     : "tnhu-ld",
     "port"     : "22",
     "username" : "tnhu",
-    "local"    : "/Users/tnhu/workspace/trunk",
-    "remote"   : "/home/tnhu/workspace/trunk"
+    "local"    : "/Users/username/project",
+    "remote"   : "/home/tnhu/project"
   }, {
     "type"     : "local",
-    "local"    : "/Users/tnhu/Library/Application Support/Sublime Text 2/Packages/SimpleSync",
-    "remote"   : "/Users/tnhu/Dropbox/projects/SimpleSync"
+    "local"    : "/Users/username/Library/Application Support/Sublime Text 2/Packages/SimpleSync",
+    "remote"   : "/Users/username/Dropbox/projects/SimpleSync"
   }]
 }
 ```
@@ -68,8 +69,8 @@ Also when you open a file, it checks its remote counterpart for if it's differen
     "host"     : "tnhu-ld",
     "port"     : "22",
     "username" : "tnhu",
-    "local"    : "/Users/tnhu/workspace/trunk",
-    "remote"   : "/home/tnhu/workspace/trunk"
+    "local"    : "/Users/username/project",
+    "remote"   : "/home/username/project"
   }]
 }
 ```


### PR DESCRIPTION
...by first copying to a temp file, then comparing local file with temp and then (if file are not equal)  asking user whether she wants to overwrite local file. There is a config parameter sync_on_open to **disable it** (it's true by default - I thought of option to enable it, but then this plugin is managed manually, so it shouldn't disrupt anyone's workflow till someone deliberately pulls changes).

Generally there should be more elaborate mechanism of handling remote changes (emacs does it pretty well), but this is something to start with. 

Let me know if you have any questions or need extra details.
